### PR TITLE
gitignore 파일에 DS_Store를 추가한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
+### Mac SettingFile ###
+.DS_Store


### PR DESCRIPTION
Mac finder 폴더에 접근을 목적으로 쓰는 DS_Store파일의 원격 git저장소 접근을 막는다.